### PR TITLE
Fixed improper command line formatting of espeak invocation. Extended…

### DIFF
--- a/tts/espeak.py
+++ b/tts/espeak.py
@@ -32,7 +32,7 @@ def say(*args):
     f.close()
 
     if male:
-        os.system('cat ' + tempFilePath + ' | espeak -v en-us+m%d -s 170--stdout | aplay -D plughw:%d,0' %(voice_number, hw_num) )
+        os.system('cat ' + tempFilePath + ' | espeak -v en-us+m%d -s 170 --stdout | aplay -D plughw:%d,0' %(voice_number, hw_num) )
     else:
         os.system('cat ' + tempFilePath + ' | espeak -v en-us+f%d -s 170 --stdout | aplay -D plughw:%d,0' % (voice_number, hw_num) )
     os.remove(tempFilePath)    

--- a/tts/espeak.py
+++ b/tts/espeak.py
@@ -32,7 +32,7 @@ def say(*args):
     f.close()
 
     if male:
-        os.system('cat ' + tempFilePath + ' | espeak --stdout | aplay -D plughw:%d,0' % hw_num)
+        os.system('cat ' + tempFilePath + ' | espeak -v en-us+m%d -s 170--stdout | aplay -D plughw:%d,0' %(voice_number, hw_num) )
     else:
-        os.system('cat ' + tempFilePath + ' | espeak -ven-us+f%d -s170 --stdout | aplay -D plughw:%d,0' % (voice_number, hw_num) )
+        os.system('cat ' + tempFilePath + ' | espeak -v en-us+f%d -s 170 --stdout | aplay -D plughw:%d,0' % (voice_number, hw_num) )
     os.remove(tempFilePath)    


### PR DESCRIPTION
… functionality to allow multiple male voices.

When the Male setting in letsrobot.conf was False, espeak would exit gracefully due to incorrect option formatting used in os.system() call.  Correcting this allows female espeak voices to work normally

The options that allow multiple female voices have been added to the male voice handling, allowing for multiple male voices to be used as well.