### PR TITLE
Fix L298N extended chat commands.

### DIFF
--- a/hardware/l298n.py
+++ b/hardware/l298n.py
@@ -17,14 +17,14 @@ def set_rotate_time(command, args):
     if extended_command.is_authed(args['name']) == 2: # Owner
         if len(command) > 1:
             rotatetimes=float(command[1])
-            log.info("rotate time multiplier set to : %d", float(command[1]))
+            log.info("rotate time multiplier set to : %f", float(command[1]))
 
 def set_sleep_time(command, args):
     global sleeptime
     if extended_command.is_authed(args['name']) == 2: # Owner
         if len(command) > 1:
             sleeptime=float(command[1])
-            log.info("sleep time set to : %d", float(command[2]))
+            log.info("sleep time set to : %f", float(command[1]))
 
 
 def setup(robot_config):


### PR DESCRIPTION
I was trying out the extended chat commands in the l298n code and found a couple of slight bugs. They incorrectly log the new values as integers rather than floats, which makes it a little confusing as to whether the correct value was actually set, and one of them tries to retrieve the value from an incorrect index value that doesn't exist when logging it and throws an exception. This should fix both of these problems.